### PR TITLE
Auth/login fixes

### DIFF
--- a/app/src/App.js
+++ b/app/src/App.js
@@ -164,6 +164,18 @@ const App = () => {
   };
 
   useEffect(() => {
+    if (document.cookie.includes("Authed-User")) {
+      const edge_state = JSON.parse(
+        document.querySelector("#edge_state").innerText
+      );
+
+      if (!Object.keys(edge_state.state).length) {
+        window.location.reload();
+      }
+    }
+  }, []);
+
+  useEffect(() => {
     const windowUrl = new URL(window.location);
     const isPaidParam = windowUrl.searchParams.get("paid");
     const lsIsPaid = localStorage.getItem("isPaid");

--- a/worker/workers-site/index.js
+++ b/worker/workers-site/index.js
@@ -49,11 +49,6 @@ async function handleEvent(event) {
     return Response.redirect(redirectUrl);
   }
 
-  // hard-refresh for kv consistency fun
-  if (url.searchParams.get("authed")) {
-    return Response.redirect(url.origin);
-  }
-
   return renderApp(event, { error, state: { accessToken } });
 }
 
@@ -176,7 +171,7 @@ const handleCallback = async (event) => {
 
   const headers = {
     Location: url.origin + `?authed=true`,
-    "Set-cookie": `${cookieKey}=${jsonKey.kid}; Max-Age=3600; Secure; SameSite=Strict;`,
+    "Set-cookie": `${cookieKey}=${jsonKey.kid}; Max-Age=3600; Secure; SameSite=Lax;`,
   };
 
   return new Response(null, {

--- a/worker/workers-site/index.js
+++ b/worker/workers-site/index.js
@@ -152,7 +152,7 @@ const handleCallback = async (event) => {
   const result = await response.json();
 
   if (result.error) {
-    return new Response(JSON.stringify(result), { status: 401 });
+    return Response.redirect(url.origin);
   }
 
   const key = await jose.JWK.createKey("oct", 256, { alg: "A256GCM" });


### PR DESCRIPTION
## Fix eventually consistent auth issue

If a user has the Authed-User cookie but no edge state, it's likely that that the corresponding KV key hasn't been set in the local KV namespace for the colo running this worker. To fix this, we'll check for Authed-User in the cookie, _and_ the edge state object being empty, and just refresh the page until it shows up.

While this seems like it could cause a loop, I've been testing this and found that it seems to resolve the problem -- because the token provided by the Authed-User cookie is validated on each request, in theory if anything ends up being invalid here, the Authed-User cookie will be purged if the token/values are incorrect at any point in this chain.

Closes #55
Closes #64 

---

## Redirect to origin on GitHub auth cancellation

Not sure why this error was put here, probably was for testing - instead of JSON stringifying an error, we should just redirect them back to the origin

Closes #53
