### PR TITLE
Use template listing on missing url component

### DIFF
--- a/app/src/App.js
+++ b/app/src/App.js
@@ -9,14 +9,13 @@ import { EdgeStateContext } from "./edge_state";
 import {
   Completed,
   Deploy,
-  ChevronLeft,
-  ChevronRight,
   Configure,
   Embed,
   GithubAuth,
   Info as InfoIcon,
   Logo,
   MissingUrl,
+  Sidebar,
 } from "./components";
 
 export const appMachine = Machine(
@@ -83,65 +82,6 @@ export const appMachine = Machine(
     },
   }
 );
-
-const Info = () => {
-  const [expanded, setExpanded] = useState(false);
-  const classes =
-    "-ml-2 flex-1 w-full bg-orange-9 border-4 border-orange-5 rounded-md hidden md:flex z-0 text-gray-1 duration-500 ease-in-out transition-transform transform ";
-  return (
-    <div
-      className={[
-        classes,
-        expanded
-          ? "p-6"
-          : "p-2 md:-translate-x-sidebar-md lg:-translate-x-sidebar-lg xl:-translate-x-sidebar-xl",
-      ].join("")}
-    >
-      <div className={expanded ? "" : "opacity-0"}>
-        <div
-          className="cursor-pointer float-right"
-          onClick={() => setExpanded(false)}
-        >
-          <ChevronLeft />
-        </div>
-
-        <h2 className="mb-4 font-semibold text-2xl">Why Workers?</h2>
-
-        <h3 className="mb-2 font-semibold text-lg">Distributed network</h3>
-        <p>
-          Deploy serverless code to Cloudflare’s edge network across 200 cities
-          and 95 countries.
-        </p>
-
-        <h3 className="mt-6 font-semibold mb-2 text-lg">Fast start</h3>
-        <p>Cold start under 5ms. 50 times faster than other platforms.</p>
-
-        <h3 className="mt-6 font-semibold mb-2 text-lg">Free Tier</h3>
-        <p>
-          First 100,000 requests each day are free and paid plans start at just
-          $5 per 10 million requests.
-        </p>
-
-        <div className="mt-6">
-          <a
-            className="font-semibold text-blue-4"
-            href="https://workers.cloudflare.com"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Learn more about Cloudflare Workers
-          </a>
-        </div>
-      </div>
-      <div className={`py-4 text-gray-3 ${expanded ? "hidden" : ""}`}>
-        <div className="cursor-pointer" onClick={() => setExpanded(true)}>
-          <ChevronRight />
-          <span className="mt-4 rotate">Why Workers</span>
-        </div>
-      </div>
-    </div>
-  );
-};
 
 const App = () => {
   const [current, send] = useMachine(appMachine);
@@ -350,7 +290,7 @@ const App = () => {
             </>
           </div>
         </div>
-        <Info />
+        <Sidebar />
       </div>
       <div className="min-w-3xl max-w-3xl w-full">
         <div className="px-10 flex-1 mt-2 text-right">

--- a/app/src/components/embed.js
+++ b/app/src/components/embed.js
@@ -47,7 +47,7 @@ const Embed = ({ quiet = false, url, linkUrl = null }) => {
               {(decodedDescription
                 ? decodedDescription
                 : embed.description
-              ).slice(0, 240)}
+              ).slice(0, 128)}
             </p>
           </div>
         </div>

--- a/app/src/components/index.js
+++ b/app/src/components/index.js
@@ -18,6 +18,7 @@ export {
 } from "./icons";
 export { default as MissingUrl } from "./missing-url";
 export { default as Section } from "./section";
+export { default as Sidebar } from "./sidebar";
 export { default as Subsection } from "./subsection";
 export { default as Templates } from "./templates";
 export { default as WorkflowStatus } from "./workflow-status";

--- a/app/src/components/missing-url.js
+++ b/app/src/components/missing-url.js
@@ -1,17 +1,18 @@
 import React from "react";
-import { Logo, Templates } from "./index";
+import { Logo, Templates, Sidebar } from "./index";
 
 export default () => {
   return (
-    <div className="flex flex-col items-center">
+    <div className="flex flex-col items-center min-h-screen">
       <Logo />
-      <div className="max-w-4xl md:w-2/3 mt-8 mx-auto md:pb-12 md:px-4 md:px-6 lg:px-8">
-        <div className="h-full bg-white rounded border flex flex-col">
+      <div className="flex">
+        <div className="flex-1" />
+        <div className="min-w-4xl max-w-4xl flex-2 min-h-full z-10 bg-white rounded border flex flex-col pt-6 pb-10 px-10">
           <div className="px-6 pt-4 flex items-center">
             <h1 className="text-header">Deploy a new project to Workers</h1>
           </div>
           <div className="flex-1 px-6 pt-4">
-            <p className="">
+            <p>
               Check out some of these great projects that are configured to
               quickly deploy to the Cloudflare Workers platform.
             </p>
@@ -36,6 +37,19 @@ export default () => {
               </a>
             </div>
           </div>
+        </div>
+        <Sidebar />
+      </div>
+      <div className="min-w-3xl max-w-3xl w-full">
+        <div className="flex-1 mt-2 text-right">
+          <a
+            className="font-semibold text-blue-4 mt-2 text-sm"
+            href="https://docs.google.com/forms/d/e/1FAIpQLScD29hGSr_ArVWuOhn7izRMw9aXfoCbkeud3qGUlZdgw32tFQ/viewform"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Feedback survey
+          </a>
         </div>
       </div>
     </div>

--- a/app/src/components/missing-url.js
+++ b/app/src/components/missing-url.js
@@ -1,111 +1,39 @@
-import React, { useRef } from "react";
-import { Logo } from "./index";
+import React from "react";
+import { Logo, Templates } from "./index";
 
 export default () => {
-  const urlRef = useRef("");
-  const setUrl = (event) => {
-    event.preventDefault();
-    const params = new URLSearchParams(window.location.search);
-    params.set("url", urlRef.current.value);
-    window.history.replaceState(
-      {},
-      "",
-      `${window.location.pathname}?${params}`
-    );
-    window.location.reload();
-  };
-
   return (
     <div className="flex flex-col items-center">
       <Logo />
       <div className="max-w-4xl md:w-2/3 mt-8 mx-auto md:pb-12 md:px-4 md:px-6 lg:px-8">
         <div className="h-full bg-white rounded border flex flex-col">
           <div className="px-6 pt-4 flex items-center">
-            <h1 className="text-header">We seem to be missing a project</h1>
+            <h1 className="text-header">Deploy a new project to Workers</h1>
           </div>
           <div className="flex-1 px-6 pt-4">
-            <p className="text-gray-1">
-              We can’t seem to find the Github repository that you are trying to
-              deploy from. This is usually caused by a misconfigured deployment
-              button.
+            <p className="">
+              Check out some of these great projects that are configured to
+              quickly deploy to the Cloudflare Workers platform.
             </p>
 
-            <p className="text-gray-1 mt-2 mb-6">
-              If you know your repository URL, you can start the process by
-              adding it below. Otherwise, checkout some of our Workers resources
-              and other projects.
+            <p className="text-gray-1 text-sm mt-2 mb-6">
+              Note: if you landed here from a "Deploy to Workers" button, the
+              button may be configured incorrectly.
             </p>
 
-            <form onSubmit={setUrl}>
-              <label className="text-gray-1" htmlFor="url">
-                Github URL
-              </label>
-              <div className="flex mt-2">
-                <input
-                  class="flex-1 border border-gray-1 rounded mr-4 text-gray-1 px-4 py-2"
-                  id="url"
-                  name="url"
-                  placeholder="Ex. https://www.github.com/danimals/repository-name"
-                  ref={urlRef}
-                />
+            <div className="flex flex-col">
+              <Templates />
+            </div>
 
-                <input
-                  type="image"
-                  name="submit"
-                  src="/deploy.svg"
-                  alt="Submit"
-                />
-              </div>
-            </form>
-
-            <div className="grid grid-cols-3 gap-4 mt-6 mb-4">
-              <div className="flex flex-col p-4 border rounded h-64">
-                <div className="flex-1">
-                  <h2 className="text-gray-1 text-lg mb-4">
-                    Workers Templates
-                  </h2>
-                  <p className="text-gray-3 text-sm">
-                    See some of the Cloudflare created Workers projects that
-                    help to demonstrate some of the capabilities of Workers.
-                  </p>
-                </div>
-                <a
-                  className="self-center text-blue-600 border border-blue-600 px-4 py-2 rounded-md"
-                  href="https://developers.cloudflare.com/docs/templates"
-                >
-                  Workers Templates
-                </a>
-              </div>
-              <div className="flex flex-col p-4 border rounded h-64">
-                <div className="flex-1">
-                  <h2 className="text-gray-1 text-lg mb-4">Popular Projects</h2>
-                  <p className="text-gray-3 text-sm">
-                    Check out what our customers have made with Workers and
-                    maybe even deploy from them.
-                  </p>
-                </div>
-                <a
-                  className="self-center text-blue-600 border border-blue-600 px-4 py-2 rounded-md"
-                  href="https://workers.cloudflare.com/built-with"
-                >
-                  Popular Projects
-                </a>
-              </div>
-              <div className="flex flex-col p-4 border rounded h-64">
-                <div className="flex-1">
-                  <h2 className="text-gray-1 text-lg mb-4">Learn more</h2>
-                  <p className="text-gray-3 text-sm">
-                    Check out why Cloudflare Workers are such a powerful tool to
-                    both small and large applications.
-                  </p>
-                </div>
-                <a
-                  className="self-center text-blue-600 border border-blue-600 px-4 py-2 rounded-md"
-                  href="https://workers.cloudflare.com"
-                >
-                  Cloudflare Workers
-                </a>
-              </div>
+            <div className="text-center py-6">
+              <a
+                className="font-semibold text-blue-4"
+                rel="noopener noreferrer"
+                target="_blank"
+                href="https://workers.cloudflare.com/built-with"
+              >
+                View more projects
+              </a>
             </div>
           </div>
         </div>

--- a/app/src/components/sidebar.js
+++ b/app/src/components/sidebar.js
@@ -1,0 +1,61 @@
+import React, { useState } from "react";
+import { ChevronLeft, ChevronRight } from "./index";
+
+export default () => {
+  const [expanded, setExpanded] = useState(false);
+  const classes =
+    "-ml-2 flex-1 w-full bg-orange-9 border-4 border-orange-5 rounded-md hidden md:flex z-0 text-gray-1 duration-500 ease-in-out transition-transform transform ";
+  return (
+    <div
+      className={[
+        classes,
+        expanded
+          ? "p-6"
+          : "p-2 max-w-sm -translate-x-sidebar md:-translate-x-sidebar-md lg:-translate-x-sidebar-lg xl:-translate-x-sidebar-xl",
+      ].join("")}
+    >
+      <div className={expanded ? "" : "opacity-0"}>
+        <div
+          className="cursor-pointer float-right"
+          onClick={() => setExpanded(false)}
+        >
+          <ChevronLeft />
+        </div>
+
+        <h2 className="mb-4 font-semibold text-2xl">Why Workers?</h2>
+
+        <h3 className="mb-2 font-semibold text-lg">Distributed network</h3>
+        <p>
+          Deploy serverless code to Cloudflare’s edge network across 200 cities
+          and 95 countries.
+        </p>
+
+        <h3 className="mt-6 font-semibold mb-2 text-lg">Fast start</h3>
+        <p>Cold start under 5ms. 50 times faster than other platforms.</p>
+
+        <h3 className="mt-6 font-semibold mb-2 text-lg">Free Tier</h3>
+        <p>
+          First 100,000 requests each day are free and paid plans start at just
+          $5 per 10 million requests.
+        </p>
+
+        <div className="mt-6">
+          <a
+            className="font-semibold text-blue-4"
+            href="https://workers.cloudflare.com"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Learn more about Cloudflare Workers
+          </a>
+        </div>
+      </div>
+      <div className={`py-4 text-gray-3 ${expanded ? "hidden" : ""}`}>
+        <div className="cursor-pointer" onClick={() => setExpanded(true)}>
+          <ChevronRight />
+          <span className="mt-4 rotate">Why Workers</span>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/app/src/components/templates.js
+++ b/app/src/components/templates.js
@@ -7,39 +7,12 @@ const TEMPLATES = [
   "https://github.com/adamschwartz/web.scraper.workers.dev",
   "https://github.com/signalnerve/workers-graphql-server",
   "https://github.com/wilsonzlin/edgesearch",
-  "https://github.com/signalnerve/cloudflare-workers-todos",
-  "https://github.com/twoflags-io/twoflags-api",
-  "https://github.com/signalnerve/repo-hunt",
 ];
 
-export default ({ current }) =>
-  current.matches("templates") ? (
-    <div className="py-2 text-lg leading-6 font-medium">
-      <div className="flex items-center text-black">
-        <>
-          <svg
-            fill="currentColor"
-            className="w-8 h-8 mr-2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"></path>
-          </svg>
-          <span>Find a project to deploy to Cloudflare Workers</span>
-        </>
-      </div>
-
-      <div className="py-8 grid grid-cols-1 xl:grid-cols-2 gap-8">
-        {TEMPLATES.map((template) => (
-          <Embed
-            key={template}
-            linkUrl={`${window.location}?url=${template}`}
-            url={template}
-          />
-        ))}
-      </div>
-    </div>
-  ) : null;
+export default () => (
+  <div className="grid grid-cols-1 gap-4">
+    {TEMPLATES.map((template) => (
+      <Embed key={template} url={template} />
+    ))}
+  </div>
+);

--- a/app/tailwind.js
+++ b/app/tailwind.js
@@ -2,9 +2,10 @@ module.exports = {
   theme: {
     extend: {
       spacing: {
-        "sidebar-md": "72%",
-        "sidebar-lg": "78%",
-        "sidebar-xl": "84%",
+        sidebar: "5rem",
+        "sidebar-md": "7rem",
+        "sidebar-lg": "7rem",
+        "sidebar-xl": "9rem",
       },
     },
   },


### PR DESCRIPTION
The "View more projects" goes to `built-with` right now, but this can be customized very easily (and directly in GitHub, if someone that isn't me wants to change this later!)

Closes #86

<img width="1015" alt="Screen Shot 2020-08-07 at 11 29 07 AM" src="https://user-images.githubusercontent.com/922353/89667137-39d7ce00-d8a1-11ea-8944-1e5b1dbce14d.png">

